### PR TITLE
Add option to use other authUser index

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -23,7 +23,7 @@ authenticated user. Not all APIs are available as a guest, so it is preferred to
 
 ### authenticate
 
-▸ **authenticate**(`cookiesStr`: *string*): *Promise*<[*IYouTubeMusicAuthenticated*](#interfaces-primaryiyoutubemusicauthenticatedmd)\>
+▸ **authenticate**(`cookiesStr`: *string*, `authUser`: *number*): *Promise*<[*IYouTubeMusicAuthenticated*](#interfaces-primaryiyoutubemusicauthenticatedmd)\>
 
 Authenticates the user with the YouTube Music API. This function overload requies the cookie string of a valid logged in user.
 
@@ -32,6 +32,7 @@ Authenticates the user with the YouTube Music API. This function overload requie
 Name | Type | Description |
 ------ | ------ | ------ |
 `cookiesStr` | *string* | The cookie string of a valid logged in user. The minimum required cookie values needed are the HSID, SSID, APISID, SAPISID, __Secure-3PSID, and __Secure-3PAPISID. To obtain this cookie value, log into https://music.youtube.com as a user and use your browser's developer tools to obtain the "cookie" value sent as a request header. Extra values in the cookie will be ignored.   |
+`authUser?` | *Number* | An optional param for auth user index (more than 1 account connected).    |
 
 **Returns:** *Promise*<[*IYouTubeMusicAuthenticated*](#interfaces-primaryiyoutubemusicauthenticatedmd)\>
 

--- a/src/service/youtube-music-authenticated.ts
+++ b/src/service/youtube-music-authenticated.ts
@@ -11,8 +11,9 @@ export default class YouTubeMusicAuthenticated extends YouTubeMusicGuest impleme
     private sapisid: string;
     private secure3psid: string;
     private secure3papisid: string;
+    private authUser: Number;
 
-    constructor(hsid: string, ssid: string, apisid: string, sapisid: string, secure3psid: string, secure3papisid: string) {
+    constructor(hsid: string, ssid: string, apisid: string, sapisid: string, secure3psid: string, secure3papisid: string, authUser: Number) {
         super();
         this.hsid = hsid;
         this.ssid = ssid;
@@ -20,13 +21,15 @@ export default class YouTubeMusicAuthenticated extends YouTubeMusicGuest impleme
         this.sapisid = sapisid;
         this.secure3psid = secure3psid;
         this.secure3papisid = secure3papisid;
+        this.authUser = authUser;
     }
 
     protected generateHeaders(): http.OutgoingHttpHeaders {
         return {
             ...super.generateHeaders(),
             "Authorization": this.generateAuthorization(),
-            "Cookie": this.generateCookie()
+            "Cookie": this.generateCookie(),
+            "X-Goog-AuthUser": this.authUser
         };
     }
 

--- a/src/service/youtube-music-authenticated.ts
+++ b/src/service/youtube-music-authenticated.ts
@@ -11,9 +11,9 @@ export default class YouTubeMusicAuthenticated extends YouTubeMusicGuest impleme
     private sapisid: string;
     private secure3psid: string;
     private secure3papisid: string;
-    private authUser: Number;
+    private authUser: number;
 
-    constructor(hsid: string, ssid: string, apisid: string, sapisid: string, secure3psid: string, secure3papisid: string, authUser: Number) {
+    constructor(hsid: string, ssid: string, apisid: string, sapisid: string, secure3psid: string, secure3papisid: string, authUser: number) {
         super();
         this.hsid = hsid;
         this.ssid = ssid;

--- a/src/service/youtube-music.ts
+++ b/src/service/youtube-music.ts
@@ -16,7 +16,7 @@ export default class YouTubeMusic implements IYouTubeMusic {
      * @param authUser X-Goog-AuthUser header value
      * @returns A promise that will yield authenticated access to the YouTube Music API.
      */
-    async authenticate(cookiesStr: string, authUser: Number = 0): Promise<IYouTubeMusicAuthenticated> {
+    async authenticate(cookiesStr: string, authUser: number = 0): Promise<IYouTubeMusicAuthenticated> {
         if (!cookiesStr) {
             throw new Error("The specific cookie string is missing");
         }

--- a/src/service/youtube-music.ts
+++ b/src/service/youtube-music.ts
@@ -13,9 +13,10 @@ export default class YouTubeMusic implements IYouTubeMusic {
      * @param cookiesStr The cookie string of a valid logged in user. The minimum required cookie values needed are the HSID, SSID, APISID,
      * SAPISID, __Secure-3PSID, and __Secure-3PAPISID. To obtain this cookie value, log into https://music.youtube.com as a user and use
      * your browser's developer tools to obtain the "cookie" value sent as a request header. Extra values in the cookie will be ignored.
+     * @param authUser X-Goog-AuthUser header value
      * @returns A promise that will yield authenticated access to the YouTube Music API.
      */
-    async authenticate(cookiesStr: string): Promise<IYouTubeMusicAuthenticated> {
+    async authenticate(cookiesStr: string, authUser: Number = 0): Promise<IYouTubeMusicAuthenticated> {
         if (!cookiesStr) {
             throw new Error("The specific cookie string is missing");
         }
@@ -36,7 +37,8 @@ export default class YouTubeMusic implements IYouTubeMusic {
             cookies.get("APISID"),
             cookies.get("SAPISID"),
             cookies.get("__Secure-3PSID"),
-            cookies.get("__Secure-3PAPISID")
+            cookies.get("__Secure-3PAPISID"),
+            authUser
         );
     }
 


### PR DESCRIPTION
I was having some trouble using the api because i have a lot of accounts connected together, so in order to fix that i added this option to select the AuthUser index.