### PR TITLE
Implement authenticated library history api

### DIFF
--- a/src/interfaces-primary.ts
+++ b/src/interfaces-primary.ts
@@ -85,6 +85,13 @@ export interface IYouTubeMusicAuthenticated extends IYouTubeMusicGuest {
     getLibraryTracks(): Promise<ITrackDetail[]>;
 
     /**
+     * Gets recently played tracks, in reverse chronological order, from the user's library
+     *
+     * @returns A promise that will yield a playlist with detailed information on a recently played tracks.
+     */
+    getLibraryHistory(): Promise<IPlaylistDetail>
+
+    /**
      * Removes the tracks from the specified playlist.
      *
      * @param playlistId The ID of the playlist to remove the tracks from.

--- a/src/service/youtube-music-authenticated.ts
+++ b/src/service/youtube-music-authenticated.ts
@@ -103,8 +103,7 @@ export default class YouTubeMusicAuthenticated extends YouTubeMusicGuest impleme
             description: 'Recently played music in reverse chronological order',
             privacy: 'PRIVATE',
             count: recentPlays.contents.length,
-            tracks: this.trackParser.parseTrackDetails(recentPlays.contents),
-            continuationToken: undefined
+            tracks: this.trackParser.parseTrackDetails(recentPlays.contents)
         }
     }
 

--- a/src/service/youtube-music-authenticated.ts
+++ b/src/service/youtube-music-authenticated.ts
@@ -1,7 +1,13 @@
 import * as http from "http";
 import sha1 from "sha1";
 import YouTubeMusicGuest from "./youtube-music-guest";
-import { IAlbumSummary, IArtistSummary, IPlaylistSummary, ITrackDetail } from "../interfaces-supplementary";
+import {
+    IAlbumSummary,
+    IArtistSummary,
+    IPlaylistDetail,
+    IPlaylistSummary,
+    ITrackDetail
+} from "../interfaces-supplementary";
 import { IYouTubeMusicAuthenticated} from "../interfaces-primary";
 
 export default class YouTubeMusicAuthenticated extends YouTubeMusicGuest implements IYouTubeMusicAuthenticated {
@@ -80,6 +86,26 @@ export default class YouTubeMusicAuthenticated extends YouTubeMusicGuest impleme
             this.trackParser.parseTracksDetailContinuation(tracksDetailResponse, continuation);
         }
         return tracksDetailResponse.tracks;
+    }
+
+    async getLibraryHistory(): Promise<IPlaylistDetail> {
+        const data = {
+            browseId: "FEmusic_history",
+        };
+        const response = await this.sendRequest("browse", data);
+
+        // cannot use parsePlaylistDetailResponse because last slice is different IE musicPlaylistShelfRenderer !== musicShelfRenderer
+        const recentPlays = this.playlistParser.traverse(response, "contents", "singleColumnBrowseResultsRenderer", "tabs", "0", "tabRenderer", "content", "sectionListRenderer", "contents", "0", "musicShelfRenderer");
+
+        return {
+            id: 'FEmusic_history', // no real id for this playlist
+            name: 'History',
+            description: 'Recently played music in reverse chronological order',
+            privacy: 'PRIVATE',
+            count: recentPlays.contents.length,
+            tracks: this.trackParser.parseTrackDetails(recentPlays.contents),
+            continuationToken: undefined
+        }
     }
 
     async createPlaylist(name: string, description?: string, privacy?: string, sourcePlaylistId?: string): Promise<IPlaylistSummary> {


### PR DESCRIPTION
Adds getLibraryHistory() to authenticated api interface with functionality on par to ytmusicapi

Closes #22