### PR TITLE
Likes thumbnails

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -38,7 +38,7 @@ A promise that will yield authenticated access to the YouTube Music API.
 
 #### Defined in
 
-[interfaces-primary.ts:17](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L17)
+[interfaces-primary.ts:17](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L17)
 
 ___
 
@@ -56,7 +56,7 @@ A promise that will yield guest access to the YouTube Music API.
 
 #### Defined in
 
-[interfaces-primary.ts:24](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L24)
+[interfaces-primary.ts:24](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L24)
 
 
 <a name="interfaces_primaryiyoutubemusicauthenticatedmd"></a>
@@ -88,6 +88,7 @@ Defines the YouTube Music APIs available to an authenticated user. An authentica
 - [getLibraryTracks](#getlibrarytracks)
 - [getPlaylist](#getplaylist)
 - [moveTrackWithinPlaylist](#movetrackwithinplaylist)
+- [rateTrack](#ratetrack)
 - [removeTracksFromPlaylist](#removetracksfromplaylist)
 
 ## Methods
@@ -113,7 +114,7 @@ A promise that will yield whether or not the operation was successful.
 
 #### Defined in
 
-[interfaces-primary.ts:38](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L38)
+[interfaces-primary.ts:38](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L38)
 
 ___
 
@@ -140,7 +141,7 @@ A promise that will yield the playlist with its ID.
 
 #### Defined in
 
-[interfaces-primary.ts:49](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L49)
+[interfaces-primary.ts:49](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L49)
 
 ___
 
@@ -164,7 +165,7 @@ A promise that will yield whether or not the operation was successful.
 
 #### Defined in
 
-[interfaces-primary.ts:57](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L57)
+[interfaces-primary.ts:57](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L57)
 
 ___
 
@@ -192,7 +193,7 @@ A promise that will yield the detailed information for a specific album.
 
 #### Defined in
 
-[interfaces-primary.ts:124](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L124)
+[interfaces-primary.ts:134](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L134)
 
 ___
 
@@ -210,7 +211,7 @@ A promise that will yield an array of all the albums in the user's library.
 
 #### Defined in
 
-[interfaces-primary.ts:64](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L64)
+[interfaces-primary.ts:64](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L64)
 
 ___
 
@@ -228,7 +229,7 @@ A promise that will yield an array of all the artists in the user's library.
 
 #### Defined in
 
-[interfaces-primary.ts:71](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L71)
+[interfaces-primary.ts:71](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L71)
 
 ___
 
@@ -246,7 +247,7 @@ A promise that will yield a playlist with detailed information on a recently pla
 
 #### Defined in
 
-[interfaces-primary.ts:92](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L92)
+[interfaces-primary.ts:92](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L92)
 
 ___
 
@@ -264,7 +265,7 @@ A promise that will yield an array of all the playlists in the user's library.
 
 #### Defined in
 
-[interfaces-primary.ts:78](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L78)
+[interfaces-primary.ts:78](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L78)
 
 ___
 
@@ -282,7 +283,7 @@ A promise that will yield an array of all the tracks in the user's library.
 
 #### Defined in
 
-[interfaces-primary.ts:85](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L85)
+[interfaces-primary.ts:85](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L85)
 
 ___
 
@@ -311,7 +312,7 @@ A promise that will yield the detailed information for a specific playlist.
 
 #### Defined in
 
-[interfaces-primary.ts:137](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L137)
+[interfaces-primary.ts:147](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L147)
 
 ___
 
@@ -337,7 +338,32 @@ A promise that will yield whether or not the operation was successful.
 
 #### Defined in
 
-[interfaces-primary.ts:102](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L102)
+[interfaces-primary.ts:102](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L102)
+
+___
+
+### rateTrack
+
+▸ **rateTrack**(`videoId`, `rating`): `Promise`<`boolean`\>
+
+Rates a song ("thumbs up"/"thumbs down" interactions on YouTube Music)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `videoId` | `string` | Video ID |
+| `rating` | ``"LIKE"`` \| ``"DISLIKE"`` \| ``"INDIFFERENT"`` | One of 'LIKE', 'DISLIKE', 'INDIFFERENT' 'INDIFFERENT' removes the previous rating and assigns no rating |
+
+#### Returns
+
+`Promise`<`boolean`\>
+
+A promise that will yield whether or not the operation was successful.
+
+#### Defined in
+
+[interfaces-primary.ts:121](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L121)
 
 ___
 
@@ -362,7 +388,7 @@ A promise that will yield whether or not the operation was successful.
 
 #### Defined in
 
-[interfaces-primary.ts:111](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L111)
+[interfaces-primary.ts:111](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L111)
 
 
 <a name="interfaces_primaryiyoutubemusicguestmd"></a>
@@ -408,7 +434,7 @@ A promise that will yield the detailed information for a specific album.
 
 #### Defined in
 
-[interfaces-primary.ts:124](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L124)
+[interfaces-primary.ts:134](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L134)
 
 ___
 
@@ -433,7 +459,7 @@ A promise that will yield the detailed information for a specific playlist.
 
 #### Defined in
 
-[interfaces-primary.ts:137](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L137)
+[interfaces-primary.ts:147](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L147)
 
 
 <a name="interfaces_supplementaryialbumdetailmd"></a>
@@ -469,7 +495,7 @@ The artist(s) that composed the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:33](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L33)
+[interfaces-supplementary.ts:33](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L33)
 
 ___
 
@@ -481,7 +507,7 @@ The count of tracks within the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:23](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L23)
+[interfaces-supplementary.ts:23](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L23)
 
 ___
 
@@ -493,7 +519,7 @@ The description of the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:18](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L18)
+[interfaces-supplementary.ts:18](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L18)
 
 ___
 
@@ -505,7 +531,7 @@ The duration of the album in milliseconds.
 
 #### Defined in
 
-[interfaces-supplementary.ts:28](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L28)
+[interfaces-supplementary.ts:28](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L28)
 
 ___
 
@@ -517,7 +543,7 @@ The ID of the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:8](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L8)
+[interfaces-supplementary.ts:8](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L8)
 
 ___
 
@@ -529,7 +555,7 @@ The name of the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:13](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L13)
+[interfaces-supplementary.ts:13](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L13)
 
 ___
 
@@ -541,7 +567,7 @@ The day the album was released.
 
 #### Defined in
 
-[interfaces-supplementary.ts:38](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L38)
+[interfaces-supplementary.ts:38](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L38)
 
 ___
 
@@ -553,7 +579,7 @@ The month the album was released.
 
 #### Defined in
 
-[interfaces-supplementary.ts:43](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L43)
+[interfaces-supplementary.ts:43](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L43)
 
 ___
 
@@ -565,7 +591,7 @@ The year the album was released.
 
 #### Defined in
 
-[interfaces-supplementary.ts:48](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L48)
+[interfaces-supplementary.ts:48](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L48)
 
 ___
 
@@ -577,7 +603,7 @@ The array of tracks within the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:53](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L53)
+[interfaces-supplementary.ts:53](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L53)
 
 
 <a name="interfaces_supplementaryialbumsummarymd"></a>
@@ -607,7 +633,7 @@ The artist that composed the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:73](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L73)
+[interfaces-supplementary.ts:73](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L73)
 
 ___
 
@@ -619,7 +645,7 @@ The ID of the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:63](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L63)
+[interfaces-supplementary.ts:63](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L63)
 
 ___
 
@@ -631,7 +657,7 @@ The name of the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:68](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L68)
+[interfaces-supplementary.ts:68](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L68)
 
 ___
 
@@ -643,7 +669,7 @@ The year the album was released.
 
 #### Defined in
 
-[interfaces-supplementary.ts:78](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L78)
+[interfaces-supplementary.ts:78](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L78)
 
 
 <a name="interfaces_supplementaryiartistsummarymd"></a>
@@ -671,7 +697,7 @@ The ID of the artist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:88](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L88)
+[interfaces-supplementary.ts:88](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L88)
 
 ___
 
@@ -683,7 +709,7 @@ The name of the artist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:93](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L93)
+[interfaces-supplementary.ts:93](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L93)
 
 
 <a name="interfaces_supplementaryiplaylistdetailmd"></a>
@@ -715,7 +741,7 @@ The count of tracks within the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:118](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L118)
+[interfaces-supplementary.ts:118](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L118)
 
 ___
 
@@ -727,7 +753,7 @@ The description of the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:113](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L113)
+[interfaces-supplementary.ts:113](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L113)
 
 ___
 
@@ -739,7 +765,7 @@ The ID of the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:103](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L103)
+[interfaces-supplementary.ts:103](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L103)
 
 ___
 
@@ -751,7 +777,7 @@ The name of the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:108](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L108)
+[interfaces-supplementary.ts:108](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L108)
 
 ___
 
@@ -763,7 +789,7 @@ The privacy level of the playlist. This value will be PUBLIC, PRIVATE, or UNLIST
 
 #### Defined in
 
-[interfaces-supplementary.ts:123](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L123)
+[interfaces-supplementary.ts:123](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L123)
 
 ___
 
@@ -775,7 +801,7 @@ The array of tracks within the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:128](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L128)
+[interfaces-supplementary.ts:128](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L128)
 
 
 <a name="interfaces_supplementaryiplaylistsummarymd"></a>
@@ -793,6 +819,7 @@ Defines a playlist summary.
 - [count](#count)
 - [id](#id)
 - [name](#name)
+- [thumbnails](#thumbnails)
 
 ## Properties
 
@@ -804,7 +831,7 @@ The count of tracks within the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:148](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L148)
+[interfaces-supplementary.ts:148](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L148)
 
 ___
 
@@ -816,7 +843,7 @@ The ID of the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:138](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L138)
+[interfaces-supplementary.ts:138](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L138)
 
 ___
 
@@ -828,7 +855,70 @@ The name of the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:143](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L143)
+[interfaces-supplementary.ts:143](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L143)
+
+___
+
+### thumbnails
+
+• `Optional` **thumbnails**: [`IThumbnail`](#interfaces_supplementaryithumbnailmd)[]
+
+Thumbsnails, ordered from smallest to larges
+
+#### Defined in
+
+[interfaces-supplementary.ts:153](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L153)
+
+
+<a name="interfaces_supplementaryithumbnailmd"></a>
+
+# Interface: IThumbnail
+
+[interfaces-supplementary](../modules/interfaces_supplementary.md).IThumbnail
+
+## Table of contents
+
+### Properties
+
+- [height](#height)
+- [url](#url)
+- [width](#width)
+
+## Properties
+
+### height
+
+• `Optional` **height**: `number`
+
+Height of thumbnail
+
+#### Defined in
+
+[interfaces-supplementary.ts:226](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L226)
+
+___
+
+### url
+
+• `Optional` **url**: `string`
+
+URL for thumbnail
+
+#### Defined in
+
+[interfaces-supplementary.ts:216](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L216)
+
+___
+
+### width
+
+• `Optional` **width**: `number`
+
+Width of thumbnail
+
+#### Defined in
+
+[interfaces-supplementary.ts:221](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L221)
 
 
 <a name="interfaces_supplementaryitrackdetailmd"></a>
@@ -849,6 +939,8 @@ Defines the details for a track.
 - [duration](#duration)
 - [durationMillis](#durationmillis)
 - [id](#id)
+- [likeStatus](#likestatus)
+- [thumbnails](#thumbnails)
 - [title](#title)
 - [trackNumber](#tracknumber)
 
@@ -862,7 +954,7 @@ The album the track is from.
 
 #### Defined in
 
-[interfaces-supplementary.ts:179](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L179)
+[interfaces-supplementary.ts:184](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L184)
 
 ___
 
@@ -875,7 +967,7 @@ is used in combination with the standard ID in order to remove tracks from playl
 
 #### Defined in
 
-[interfaces-supplementary.ts:164](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L164)
+[interfaces-supplementary.ts:169](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L169)
 
 ___
 
@@ -887,7 +979,7 @@ The artist(s) that compose the track.
 
 #### Defined in
 
-[interfaces-supplementary.ts:174](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L174)
+[interfaces-supplementary.ts:179](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L179)
 
 ___
 
@@ -899,7 +991,7 @@ The duration of the track as a readable string.
 
 #### Defined in
 
-[interfaces-supplementary.ts:184](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L184)
+[interfaces-supplementary.ts:189](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L189)
 
 ___
 
@@ -911,7 +1003,7 @@ The duration of the track in milliseconds.
 
 #### Defined in
 
-[interfaces-supplementary.ts:189](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L189)
+[interfaces-supplementary.ts:194](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L194)
 
 ___
 
@@ -923,7 +1015,31 @@ The ID of the track.
 
 #### Defined in
 
-[interfaces-supplementary.ts:158](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L158)
+[interfaces-supplementary.ts:163](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L163)
+
+___
+
+### likeStatus
+
+• `Optional` **likeStatus**: ``"LIKE"`` \| ``"DISLIKE"`` \| ``"INDIFFERENT"``
+
+Like status. One of LIKE, DISLIKE, INDIFFERENT
+
+#### Defined in
+
+[interfaces-supplementary.ts:209](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L209)
+
+___
+
+### thumbnails
+
+• `Optional` **thumbnails**: [`IThumbnail`](#interfaces_supplementaryithumbnailmd)[]
+
+Thumbsnails, ordered from smallest to larges
+
+#### Defined in
+
+[interfaces-supplementary.ts:204](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L204)
 
 ___
 
@@ -935,7 +1051,7 @@ The title of the track.
 
 #### Defined in
 
-[interfaces-supplementary.ts:169](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L169)
+[interfaces-supplementary.ts:174](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L174)
 
 ___
 
@@ -947,4 +1063,4 @@ The track number within an album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:194](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L194)
+[interfaces-supplementary.ts:199](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L199)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -38,7 +38,7 @@ A promise that will yield authenticated access to the YouTube Music API.
 
 #### Defined in
 
-[interfaces-primary.ts:17](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L17)
+[interfaces-primary.ts:17](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L17)
 
 ___
 
@@ -56,7 +56,7 @@ A promise that will yield guest access to the YouTube Music API.
 
 #### Defined in
 
-[interfaces-primary.ts:24](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L24)
+[interfaces-primary.ts:24](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L24)
 
 
 <a name="interfaces_primaryiyoutubemusicauthenticatedmd"></a>
@@ -114,7 +114,7 @@ A promise that will yield whether or not the operation was successful.
 
 #### Defined in
 
-[interfaces-primary.ts:38](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L38)
+[interfaces-primary.ts:38](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L38)
 
 ___
 
@@ -141,7 +141,7 @@ A promise that will yield the playlist with its ID.
 
 #### Defined in
 
-[interfaces-primary.ts:49](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L49)
+[interfaces-primary.ts:49](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L49)
 
 ___
 
@@ -165,7 +165,7 @@ A promise that will yield whether or not the operation was successful.
 
 #### Defined in
 
-[interfaces-primary.ts:57](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L57)
+[interfaces-primary.ts:57](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L57)
 
 ___
 
@@ -193,7 +193,7 @@ A promise that will yield the detailed information for a specific album.
 
 #### Defined in
 
-[interfaces-primary.ts:134](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L134)
+[interfaces-primary.ts:134](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L134)
 
 ___
 
@@ -211,7 +211,7 @@ A promise that will yield an array of all the albums in the user's library.
 
 #### Defined in
 
-[interfaces-primary.ts:64](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L64)
+[interfaces-primary.ts:64](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L64)
 
 ___
 
@@ -229,7 +229,7 @@ A promise that will yield an array of all the artists in the user's library.
 
 #### Defined in
 
-[interfaces-primary.ts:71](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L71)
+[interfaces-primary.ts:71](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L71)
 
 ___
 
@@ -247,7 +247,7 @@ A promise that will yield a playlist with detailed information on a recently pla
 
 #### Defined in
 
-[interfaces-primary.ts:92](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L92)
+[interfaces-primary.ts:92](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L92)
 
 ___
 
@@ -265,7 +265,7 @@ A promise that will yield an array of all the playlists in the user's library.
 
 #### Defined in
 
-[interfaces-primary.ts:78](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L78)
+[interfaces-primary.ts:78](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L78)
 
 ___
 
@@ -283,7 +283,7 @@ A promise that will yield an array of all the tracks in the user's library.
 
 #### Defined in
 
-[interfaces-primary.ts:85](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L85)
+[interfaces-primary.ts:85](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L85)
 
 ___
 
@@ -312,7 +312,7 @@ A promise that will yield the detailed information for a specific playlist.
 
 #### Defined in
 
-[interfaces-primary.ts:147](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L147)
+[interfaces-primary.ts:147](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L147)
 
 ___
 
@@ -338,7 +338,7 @@ A promise that will yield whether or not the operation was successful.
 
 #### Defined in
 
-[interfaces-primary.ts:102](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L102)
+[interfaces-primary.ts:102](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L102)
 
 ___
 
@@ -363,7 +363,7 @@ A promise that will yield whether or not the operation was successful.
 
 #### Defined in
 
-[interfaces-primary.ts:121](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L121)
+[interfaces-primary.ts:121](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L121)
 
 ___
 
@@ -388,7 +388,7 @@ A promise that will yield whether or not the operation was successful.
 
 #### Defined in
 
-[interfaces-primary.ts:111](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L111)
+[interfaces-primary.ts:111](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L111)
 
 
 <a name="interfaces_primaryiyoutubemusicguestmd"></a>
@@ -434,7 +434,7 @@ A promise that will yield the detailed information for a specific album.
 
 #### Defined in
 
-[interfaces-primary.ts:134](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L134)
+[interfaces-primary.ts:134](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L134)
 
 ___
 
@@ -459,7 +459,7 @@ A promise that will yield the detailed information for a specific playlist.
 
 #### Defined in
 
-[interfaces-primary.ts:147](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L147)
+[interfaces-primary.ts:147](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-primary.ts#L147)
 
 
 <a name="interfaces_supplementaryialbumdetailmd"></a>
@@ -495,7 +495,7 @@ The artist(s) that composed the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:33](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L33)
+[interfaces-supplementary.ts:33](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L33)
 
 ___
 
@@ -507,7 +507,7 @@ The count of tracks within the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:23](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L23)
+[interfaces-supplementary.ts:23](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L23)
 
 ___
 
@@ -519,7 +519,7 @@ The description of the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:18](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L18)
+[interfaces-supplementary.ts:18](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L18)
 
 ___
 
@@ -531,7 +531,7 @@ The duration of the album in milliseconds.
 
 #### Defined in
 
-[interfaces-supplementary.ts:28](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L28)
+[interfaces-supplementary.ts:28](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L28)
 
 ___
 
@@ -543,7 +543,7 @@ The ID of the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:8](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L8)
+[interfaces-supplementary.ts:8](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L8)
 
 ___
 
@@ -555,7 +555,7 @@ The name of the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:13](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L13)
+[interfaces-supplementary.ts:13](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L13)
 
 ___
 
@@ -567,7 +567,7 @@ The day the album was released.
 
 #### Defined in
 
-[interfaces-supplementary.ts:38](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L38)
+[interfaces-supplementary.ts:38](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L38)
 
 ___
 
@@ -579,7 +579,7 @@ The month the album was released.
 
 #### Defined in
 
-[interfaces-supplementary.ts:43](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L43)
+[interfaces-supplementary.ts:43](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L43)
 
 ___
 
@@ -591,7 +591,7 @@ The year the album was released.
 
 #### Defined in
 
-[interfaces-supplementary.ts:48](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L48)
+[interfaces-supplementary.ts:48](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L48)
 
 ___
 
@@ -603,7 +603,7 @@ The array of tracks within the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:53](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L53)
+[interfaces-supplementary.ts:53](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L53)
 
 
 <a name="interfaces_supplementaryialbumsummarymd"></a>
@@ -633,7 +633,7 @@ The artist that composed the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:73](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L73)
+[interfaces-supplementary.ts:73](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L73)
 
 ___
 
@@ -645,7 +645,7 @@ The ID of the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:63](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L63)
+[interfaces-supplementary.ts:63](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L63)
 
 ___
 
@@ -657,7 +657,7 @@ The name of the album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:68](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L68)
+[interfaces-supplementary.ts:68](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L68)
 
 ___
 
@@ -669,7 +669,7 @@ The year the album was released.
 
 #### Defined in
 
-[interfaces-supplementary.ts:78](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L78)
+[interfaces-supplementary.ts:78](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L78)
 
 
 <a name="interfaces_supplementaryiartistsummarymd"></a>
@@ -697,7 +697,7 @@ The ID of the artist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:88](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L88)
+[interfaces-supplementary.ts:88](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L88)
 
 ___
 
@@ -709,7 +709,7 @@ The name of the artist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:93](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L93)
+[interfaces-supplementary.ts:93](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L93)
 
 
 <a name="interfaces_supplementaryiplaylistdetailmd"></a>
@@ -741,7 +741,7 @@ The count of tracks within the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:118](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L118)
+[interfaces-supplementary.ts:118](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L118)
 
 ___
 
@@ -753,7 +753,7 @@ The description of the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:113](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L113)
+[interfaces-supplementary.ts:113](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L113)
 
 ___
 
@@ -765,7 +765,7 @@ The ID of the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:103](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L103)
+[interfaces-supplementary.ts:103](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L103)
 
 ___
 
@@ -777,7 +777,7 @@ The name of the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:108](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L108)
+[interfaces-supplementary.ts:108](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L108)
 
 ___
 
@@ -789,7 +789,7 @@ The privacy level of the playlist. This value will be PUBLIC, PRIVATE, or UNLIST
 
 #### Defined in
 
-[interfaces-supplementary.ts:123](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L123)
+[interfaces-supplementary.ts:123](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L123)
 
 ___
 
@@ -801,7 +801,7 @@ The array of tracks within the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:128](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L128)
+[interfaces-supplementary.ts:128](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L128)
 
 
 <a name="interfaces_supplementaryiplaylistsummarymd"></a>
@@ -831,7 +831,7 @@ The count of tracks within the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:148](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L148)
+[interfaces-supplementary.ts:148](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L148)
 
 ___
 
@@ -843,7 +843,7 @@ The ID of the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:138](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L138)
+[interfaces-supplementary.ts:138](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L138)
 
 ___
 
@@ -855,7 +855,7 @@ The name of the playlist.
 
 #### Defined in
 
-[interfaces-supplementary.ts:143](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L143)
+[interfaces-supplementary.ts:143](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L143)
 
 ___
 
@@ -867,7 +867,7 @@ Thumbsnails, ordered from smallest to larges
 
 #### Defined in
 
-[interfaces-supplementary.ts:153](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L153)
+[interfaces-supplementary.ts:153](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L153)
 
 
 <a name="interfaces_supplementaryithumbnailmd"></a>
@@ -894,7 +894,7 @@ Height of thumbnail
 
 #### Defined in
 
-[interfaces-supplementary.ts:226](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L226)
+[interfaces-supplementary.ts:226](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L226)
 
 ___
 
@@ -906,7 +906,7 @@ URL for thumbnail
 
 #### Defined in
 
-[interfaces-supplementary.ts:216](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L216)
+[interfaces-supplementary.ts:216](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L216)
 
 ___
 
@@ -918,7 +918,7 @@ Width of thumbnail
 
 #### Defined in
 
-[interfaces-supplementary.ts:221](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L221)
+[interfaces-supplementary.ts:221](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L221)
 
 
 <a name="interfaces_supplementaryitrackdetailmd"></a>
@@ -954,7 +954,7 @@ The album the track is from.
 
 #### Defined in
 
-[interfaces-supplementary.ts:184](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L184)
+[interfaces-supplementary.ts:184](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L184)
 
 ___
 
@@ -967,7 +967,7 @@ is used in combination with the standard ID in order to remove tracks from playl
 
 #### Defined in
 
-[interfaces-supplementary.ts:169](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L169)
+[interfaces-supplementary.ts:169](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L169)
 
 ___
 
@@ -979,7 +979,7 @@ The artist(s) that compose the track.
 
 #### Defined in
 
-[interfaces-supplementary.ts:179](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L179)
+[interfaces-supplementary.ts:179](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L179)
 
 ___
 
@@ -991,7 +991,7 @@ The duration of the track as a readable string.
 
 #### Defined in
 
-[interfaces-supplementary.ts:189](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L189)
+[interfaces-supplementary.ts:189](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L189)
 
 ___
 
@@ -1003,7 +1003,7 @@ The duration of the track in milliseconds.
 
 #### Defined in
 
-[interfaces-supplementary.ts:194](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L194)
+[interfaces-supplementary.ts:194](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L194)
 
 ___
 
@@ -1015,7 +1015,7 @@ The ID of the track.
 
 #### Defined in
 
-[interfaces-supplementary.ts:163](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L163)
+[interfaces-supplementary.ts:163](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L163)
 
 ___
 
@@ -1027,7 +1027,7 @@ Like status. One of LIKE, DISLIKE, INDIFFERENT
 
 #### Defined in
 
-[interfaces-supplementary.ts:209](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L209)
+[interfaces-supplementary.ts:209](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L209)
 
 ___
 
@@ -1039,7 +1039,7 @@ Thumbsnails, ordered from smallest to larges
 
 #### Defined in
 
-[interfaces-supplementary.ts:204](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L204)
+[interfaces-supplementary.ts:204](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L204)
 
 ___
 
@@ -1051,7 +1051,7 @@ The title of the track.
 
 #### Defined in
 
-[interfaces-supplementary.ts:174](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L174)
+[interfaces-supplementary.ts:174](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L174)
 
 ___
 
@@ -1063,4 +1063,4 @@ The track number within an album.
 
 #### Defined in
 
-[interfaces-supplementary.ts:199](https://github.com/theyak/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L199)
+[interfaces-supplementary.ts:199](https://github.com/nickp10/youtube-music-ts-api/blob/master/src/interfaces-supplementary.ts#L199)

--- a/src/interfaces-primary.ts
+++ b/src/interfaces-primary.ts
@@ -109,6 +109,16 @@ export interface IYouTubeMusicAuthenticated extends IYouTubeMusicGuest {
      * @returns A promise that will yield whether or not the operation was successful.
      */
     removeTracksFromPlaylist(playlistId: string, ...tracks: ITrackDetail[]): Promise<boolean>;
+
+    /**
+     * Rates a song ("thumbs up"/"thumbs down" interactions on YouTube Music)
+     *
+     * @param videoId Video ID
+     * @param rating One of 'LIKE', 'DISLIKE', 'INDIFFERENT'
+     *   'INDIFFERENT' removes the previous rating and assigns no rating
+     * @returns A promise that will yield whether or not the operation was successful.
+     */
+    rateTrack(videoId: string, rating: "LIKE"|"DISLIKE"|"INDIFFERENT"): Promise<boolean>;
 }
 
 /**
@@ -129,7 +139,7 @@ export interface IYouTubeMusicGuest {
      * @param id The ID of the playlist to get the detailed information for.
      * @param maxRetries An optional maximum number of retries to obtain the tracks. YouTube Music is
      * incredibly buggy in that not all tracks will be returned in a single request. If the request is
-     * retried, you may get a different set of tracks in the response. If you retry enough times, you 
+     * retried, you may get a different set of tracks in the response. If you retry enough times, you
      * will eventually get all the tracks (a union operation is done internally between all the tracks
      * returned from each individual request).
      * @returns A promise that will yield the detailed information for a specific playlist.

--- a/src/interfaces-supplementary.ts
+++ b/src/interfaces-supplementary.ts
@@ -225,3 +225,4 @@ export interface IThumbnail {
      */
     height?: number,
 }
+

--- a/src/interfaces-supplementary.ts
+++ b/src/interfaces-supplementary.ts
@@ -146,6 +146,11 @@ export interface IPlaylistSummary {
      * The count of tracks within the playlist.
      */
     count?: number;
+
+    /**
+     * Thumbsnails, ordered from smallest to larges
+     */
+    thumbnails?: IThumbnail[];
 }
 
 /**
@@ -192,4 +197,31 @@ export interface ITrackDetail {
      * The track number within an album.
      */
     trackNumber?: number;
+
+    /**
+     * Thumbsnails, ordered from smallest to larges
+     */
+     thumbnails?: IThumbnail[];
+
+     /**
+      * Like status. One of LIKE, DISLIKE, INDIFFERENT
+      */
+     likeStatus?: "LIKE"|"DISLIKE"|"INDIFFERENT";
+}
+
+export interface IThumbnail {
+    /**
+     * URL for thumbnail
+     */
+    url?: string,
+
+    /**
+     * Width of thumbnail
+     */
+    width?: number,
+
+    /**
+     * Height of thumbnail
+     */
+    height?: number,
 }

--- a/src/interfaces-supplementary.ts
+++ b/src/interfaces-supplementary.ts
@@ -225,4 +225,3 @@ export interface IThumbnail {
      */
     height?: number,
 }
-

--- a/src/parsers/playlist-parser.ts
+++ b/src/parsers/playlist-parser.ts
@@ -42,9 +42,11 @@ export default class PlaylistParser extends BaseParser {
                 }
             }
         }
+
         return {
             id: this.traverse(playlistObj, "musicTwoRowItemRenderer", "title", "runs", "0", "navigationEndpoint", "browseEndpoint", "browseId"),
             name: this.traverse(playlistObj, "musicTwoRowItemRenderer", "title", "runs", "0", "text"),
+            thumbnails: this.traverse(playlistObj, "musicTwoRowItemRenderer", "thumbnailRenderer", "musicThumbnailRenderer", "thumbnail", "thumbnails"),
             count: count
         };
     }

--- a/src/service/youtube-music-authenticated.ts
+++ b/src/service/youtube-music-authenticated.ts
@@ -68,6 +68,7 @@ export default class YouTubeMusicAuthenticated extends YouTubeMusicGuest impleme
         const response = await this.sendRequest("browse", {
             browseId: "FEmusic_liked_playlists",
         });
+
         return this.playlistParser.parsePlaylistsSummaryResponse(response);
     }
 
@@ -181,6 +182,34 @@ export default class YouTubeMusicAuthenticated extends YouTubeMusicGuest impleme
             playlistId: this.playlistIdTrim(playlistId),
             actions: actions
         });
+        return response.status === "STATUS_SUCCEEDED";
+    }
+
+    /**
+     * Rates a song ("thumbs up"/"thumbs down" interactions on YouTube Music)
+     *
+     * @param videoId Video ID
+     * @param rating One of 'LIKE', 'DISLIKE', 'INDIFFERENT'
+     *   'INDIFFERENT' removes the previous rating and assigns no rating
+     * @returns
+     */
+    async rateTrack(videoId: string, rating: "LIKE"|"DISLIKE"|"INDIFFERENT"): Promise<boolean> {
+        let endpoint: string;
+
+        if (rating === "LIKE") {
+            endpoint = "like/like";
+        } else if (rating === "DISLIKE") {
+            endpoint = "like/dislike";
+        } else {
+            endpoint = "like/removelike";
+        }
+
+        const response = await this.sendRequest(endpoint, {
+            target: {
+                videoId: videoId,
+            }
+        });
+
         return response.status === "STATUS_SUCCEEDED";
     }
 }

--- a/src/service/youtube-music-base.ts
+++ b/src/service/youtube-music-base.ts
@@ -31,7 +31,7 @@ export default class YouTubeMusicBase {
     }
 
     protected async sendRequest(path: string, data?: any, additionalQueryString?: string): Promise<any> {
-        let dataStr: string = undefined;
+        let dataStr: string|undefined = undefined;
         if (data) {
             data = {
                 ...YouTubeMusicContext,


### PR DESCRIPTION
This PR adds thumbnails to playlist and track objects and like status of track objects. A new endpoint, `rateTrack(videoId, rating)` has also been added to the possible endpoints that can be called.